### PR TITLE
Add rating reset features and logout

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -17,11 +17,16 @@
         function goToTierlist() {
             window.location.href = 'tierlist.html';
         }
+        function logout() {
+            localStorage.removeItem('currentUser');
+            window.location.href = 'index.html';
+        }
     </script>
 </head>
 <body class="menu-page">
     <header class="menu-header">
         <h2>Welcome, <span id="header-user">User</span>!</h2>
+        <button onclick="logout()" class="secondary-button">LOGOUT</button>
     </header>
     <main class="menu-main">
         <button class="primary-button" onclick="goToTierlist()">LEAGUE TIERLIST</button>

--- a/rate.html
+++ b/rate.html
@@ -29,6 +29,10 @@
             const key = 'ratings_' + getCurrentUser();
             localStorage.setItem(key, JSON.stringify(ratings));
         }
+        function logout() {
+            localStorage.removeItem('currentUser');
+            window.location.href = 'index.html';
+        }
         async function loadSkins() {
             // Use globally defined skin data array
             skinsData = window.SKINS_DATA || [];
@@ -86,6 +90,7 @@
 <body class="rate-page">
     <header class="rate-header">
         <button onclick="window.location.href='tierlist.html'" class="secondary-button">Back to Tierlist</button>
+        <button onclick="logout()" class="secondary-button">LOGOUT</button>
     </header>
     <main class="rate-main">
         <div id="rating-container" class="rating-card">

--- a/styles.css
+++ b/styles.css
@@ -77,7 +77,9 @@ button:hover {
 .menu-header {
     padding: 1rem;
     background-color: #161b22;
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     border-bottom: 1px solid #30363d;
 }
 .menu-main {
@@ -100,7 +102,10 @@ button:hover {
 .tierlist-header {
     padding: 1rem;
     background-color: #161b22;
-    text-align: right;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
     border-bottom: 1px solid #30363d;
 }
 .tierlist-header .primary-button {
@@ -121,6 +126,7 @@ button:hover {
     border: 1px solid #30363d;
     border-radius: 8px;
     overflow: hidden;
+    position: relative;
     display: flex;
     flex-direction: column;
     box-shadow: 0 2px 4px rgba(0,0,0,0.4);
@@ -144,6 +150,18 @@ button:hover {
     color: #8b949e;
 }
 
+.reset-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    display: none;
+    padding: 2px 6px;
+    font-size: 0.7rem;
+}
+.skin-card:hover .reset-btn {
+    display: block;
+}
+
 /* Rate page */
 .rate-page {
     display: flex;
@@ -153,6 +171,9 @@ button:hover {
 .rate-header {
     padding: 1rem;
     background-color: #161b22;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     border-bottom: 1px solid #30363d;
 }
 .rate-main {
@@ -167,7 +188,7 @@ button:hover {
     border: 1px solid #30363d;
     border-radius: 8px;
     padding: 1rem;
-    max-width: 450px;
+    max-width: 600px;
     text-align: center;
     box-shadow: 0 2px 4px rgba(0,0,0,0.4);
     transition: transform 0.4s ease, opacity 0.4s ease;
@@ -184,7 +205,7 @@ button:hover {
 .rating-image {
     width: 100%;
     height: auto;
-    max-height: 300px;
+    max-height: 450px;
     object-fit: contain;
     border-radius: 4px;
     margin-bottom: 1rem;

--- a/tierlist.html
+++ b/tierlist.html
@@ -10,6 +10,48 @@
     <script>
         const USERS = ['User1','User2','User3','User4'];
         const RATING_LABELS = ['Dogshit','Cringe','Basic','Awesome','Supreme','Perfect'];
+        function getCurrentUser() {
+            return localStorage.getItem('currentUser');
+        }
+        function getUserRatings() {
+            const key = 'ratings_' + getCurrentUser();
+            try {
+                return JSON.parse(localStorage.getItem(key)) || {};
+            } catch (err) {
+                return {};
+            }
+        }
+        function setUserRatings(ratings) {
+            const key = 'ratings_' + getCurrentUser();
+            localStorage.setItem(key, JSON.stringify(ratings));
+        }
+        function logout() {
+            localStorage.removeItem('currentUser');
+            window.location.href = 'index.html';
+        }
+        function resetAll() {
+            if (!confirm('Reset all ratings?')) return;
+            setUserRatings({});
+            populateGrid();
+        }
+        function resetChampion(champ) {
+            if (!champ) return;
+            if (!confirm(`Reset ratings for ${champ}?`)) return;
+            const ratings = getUserRatings();
+            (window.SKINS_DATA || []).forEach(s => {
+                if (s.champion === champ) delete ratings[s.image];
+            });
+            setUserRatings(ratings);
+            populateGrid();
+        }
+        function resetSkin(imageKey) {
+            const ratings = getUserRatings();
+            if (ratings[imageKey] !== undefined) {
+                delete ratings[imageKey];
+                setUserRatings(ratings);
+                populateGrid();
+            }
+        }
         // Convert a numeric rating (0–5) to its textual label.
         function ratingToLabel(num) {
             return RATING_LABELS[num] ?? 'Unrated';
@@ -38,8 +80,20 @@
         // Generate the HTML grid based on data and insert into the DOM.
         async function populateGrid() {
             const grid = document.getElementById('skin-grid');
+            grid.innerHTML = '';
             // Use the globally loaded skins array
             const skins = window.SKINS_DATA || [];
+            // Populate champion selector once
+            const champSelect = document.getElementById('champ-select');
+            if (champSelect && champSelect.options.length <= 1) {
+                const champs = [...new Set(skins.map(s => s.champion))].sort();
+                champs.forEach(c => {
+                    const opt = document.createElement('option');
+                    opt.value = c;
+                    opt.textContent = c;
+                    champSelect.appendChild(opt);
+                });
+            }
             // Augment each skin with average rating and number of ratings
             skins.forEach((skin) => {
                 const avg = computeAverage(skin.image);
@@ -63,6 +117,14 @@
             for (const skin of skins) {
                 const card = document.createElement('div');
                 card.className = 'skin-card';
+                const reset = document.createElement('button');
+                reset.textContent = 'Reset';
+                reset.className = 'secondary-button reset-btn';
+                reset.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    resetSkin(skin.image);
+                });
+                card.appendChild(reset);
                 const img = document.createElement('img');
                 img.src = skin.image;
                 img.alt = `${skin.champion} – ${skin.skin}`;
@@ -91,6 +153,17 @@
             startButton.addEventListener('click', () => {
                 window.location.href = 'rate.html';
             });
+            const resetAllBtn = document.getElementById('reset-all');
+            if (resetAllBtn) {
+                resetAllBtn.addEventListener('click', resetAll);
+            }
+            const resetChampBtn = document.getElementById('reset-champ');
+            if (resetChampBtn) {
+                resetChampBtn.addEventListener('click', () => {
+                    const sel = document.getElementById('champ-select');
+                    resetChampion(sel ? sel.value : '');
+                });
+            }
             populateGrid();
         });
     </script>
@@ -98,6 +171,12 @@
 <body class="tierlist-page">
     <header class="tierlist-header">
         <button id="start-rating" class="primary-button">START RATING</button>
+        <select id="champ-select">
+            <option value="">Select Champion</option>
+        </select>
+        <button id="reset-champ" class="secondary-button">Reset Champ</button>
+        <button id="reset-all" class="secondary-button">Reset All</button>
+        <button onclick="logout()" class="secondary-button">LOGOUT</button>
     </header>
     <main class="tierlist-main">
         <div id="skin-grid" class="grid-container"></div>


### PR DESCRIPTION
## Summary
- grow rating images for better visibility
- add logout buttons to rate, menu and tierlist screens
- allow resetting ratings (all, per champion, or per skin)
- introduce hover reset button on each skin card
- adjust headers styling for new controls

## Testing
- `npm start` (server runs)

------
https://chatgpt.com/codex/tasks/task_e_688c6ff7c814832d8a6e1fb6e34144ca