### PR TITLE
Add ngrok support docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ npm start
 
 The application will be available at http://localhost:3000 (or the port set in
 `PORT`). The server simply serves the static files in this repository.
+
+## Exposing with ngrok
+
+To share the development server over the internet you can use [ngrok](https://ngrok.com/).
+After installing ngrok and logging in, run the following command in a separate
+terminal after starting the server:
+
+```bash
+ngrok http --url=complete-sloth-ultimately.ngrok-free.app 3000
+```
+
+This will make the site available at
+`https://complete-sloth-ultimately.ngrok-free.app`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Basic Node.js server for League Tierlist site",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "tunnel": "ngrok http --url=complete-sloth-ultimately.ngrok-free.app 3000"
   },
   "dependencies": {
     "express": "^4.18.2"


### PR DESCRIPTION
## Summary
- add instructions for exposing the site via ngrok in the README
- add an npm script to open a tunnel with ngrok
- ignore package-lock.json so it isn't accidentally committed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688c709263c4832db8085ef773f91aa2