### PR TITLE
Fix synchronous rating advance

### DIFF
--- a/rate.html
+++ b/rate.html
@@ -89,7 +89,9 @@
                     showNextSkin();
                     return;
                 }
-                if (!data.waitingFor.includes(getCurrentUser())) {
+                const skinChanged = data.skin && currentSkin && data.skin.image !== currentSkin.image;
+                const notWaiting = !data.waitingFor.includes(getCurrentUser());
+                if (skinChanged || notWaiting) {
                     clearInterval(waitingInterval);
                     waitingInterval = null;
                     document.getElementById('wait-message').classList.add('hidden');


### PR DESCRIPTION
## Summary
- update startPolling in **rate.html**

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_688c74ffe898832d97a0cd24fd6c01f4