### PR TITLE
Fix sync rating session not advancing

### DIFF
--- a/rate.html
+++ b/rate.html
@@ -89,7 +89,9 @@
                     showNextSkin();
                     return;
                 }
-                if (!data.waitingFor.includes(getCurrentUser())) {
+                const meWaiting = data.waitingFor.includes(getCurrentUser());
+                const skinChanged = currentSkin && data.skin.image !== currentSkin.image;
+                if (!meWaiting || skinChanged) {
                     clearInterval(waitingInterval);
                     waitingInterval = null;
                     document.getElementById('wait-message').classList.add('hidden');
@@ -103,7 +105,7 @@
             const resp = await fetch('/api/sync/toggle', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({enabled: newVal})
+                body: JSON.stringify({enabled: newVal, user: getCurrentUser()})
             });
             const data = await resp.json();
             syncMode = data.enabled;
@@ -111,7 +113,11 @@
             const btn = document.getElementById('sync-toggle');
             if (btn) btn.textContent = syncMode ? 'SYNC ON' : 'SYNCH SESSION';
             if (syncMode) {
-                await fetchSyncSkin();
+                if (data.skin) {
+                    updateDomForSkin(data.skin);
+                } else {
+                    await fetchSyncSkin();
+                }
             } else {
                 showNextSkin();
             }
@@ -123,6 +129,10 @@
             setUserRatings(userRatings);
             const container = document.getElementById('rating-container');
             container.classList.add('rated');
+            if (waitingInterval) {
+                clearInterval(waitingInterval);
+                waitingInterval = null;
+            }
             if (syncMode) {
                 const resp = await fetch('/api/sync/rate', {
                     method: 'POST',
@@ -188,7 +198,7 @@
                 <button>Supreme</button>
                 <button>Perfect</button>
             </div>
-            <div id="wait-message" class="waiting-message hidden">Waiting for others...</div>
+            <div id="wait-message" class="waiting-message hidden"><span class="spinner"></span>Waiting for others...</div>
         </div>
         <div id="finished-container" class="finished" style="display:none;">
             <h2>All skins have been rated!</h2>

--- a/rate.html
+++ b/rate.html
@@ -16,6 +16,22 @@
         let syncMode = false;
         let waitingInterval = null;
 
+        function renderSessionUsers(participants = [], waitingFor = []) {
+            const container = document.getElementById('session-users');
+            container.innerHTML = '';
+            participants.forEach(name => {
+                const span = document.createElement('span');
+                span.textContent = name;
+                span.classList.add(waitingFor.includes(name) ? 'waiting' : 'rated');
+                container.appendChild(span);
+            });
+            if (participants.length) {
+                container.classList.remove('hidden');
+            } else {
+                container.classList.add('hidden');
+            }
+        }
+
         function getCurrentUser() {
             return localStorage.getItem('currentUser');
         }
@@ -71,9 +87,11 @@
                 syncMode = false;
                 localStorage.setItem('syncMode', 'false');
                 showNextSkin();
+                renderSessionUsers([], []);
                 return;
             }
             updateDomForSkin(data.skin);
+            renderSessionUsers(data.participants, data.waitingFor);
         }
 
         function startPolling() {
@@ -87,14 +105,16 @@
                     syncMode = false;
                     localStorage.setItem('syncMode', 'false');
                     showNextSkin();
+                    renderSessionUsers([], []);
                     return;
                 }
-                const meWaiting = data.waitingFor.includes(getCurrentUser());
                 const skinChanged = currentSkin && data.skin.image !== currentSkin.image;
-                if (!meWaiting || skinChanged) {
+                renderSessionUsers(data.participants, data.waitingFor);
+                if (skinChanged) {
                     clearInterval(waitingInterval);
                     waitingInterval = null;
                     document.getElementById('wait-message').classList.add('hidden');
+                    renderSessionUsers([], []);
                     updateDomForSkin(data.skin);
                 }
             }, 1000);
@@ -118,8 +138,10 @@
                 } else {
                     await fetchSyncSkin();
                 }
+                renderSessionUsers(data.participants, data.waitingFor);
             } else {
                 showNextSkin();
+                renderSessionUsers([], []);
             }
         }
         async function rateSkin(ratingValue) {
@@ -144,19 +166,23 @@
                     container.classList.remove('rated');
                     if (data.nextSkin) {
                         updateDomForSkin(data.nextSkin);
+                        renderSessionUsers(data.participants, data.waitingFor);
                     } else if (data.waiting) {
                         document.getElementById('wait-message').classList.remove('hidden');
+                        renderSessionUsers(data.participants, data.waitingFor);
                         startPolling();
                     } else {
                         showNextSkin();
+                        renderSessionUsers([], []);
                     }
                 }, 400);
-            } else {
-                setTimeout(() => {
-                    container.classList.remove('rated');
-                    showNextSkin();
-                }, 400);
-            }
+           } else {
+               setTimeout(() => {
+                   container.classList.remove('rated');
+                   showNextSkin();
+                    renderSessionUsers([], []);
+               }, 400);
+           }
         }
         window.addEventListener('DOMContentLoaded', () => {
             const buttons = document.querySelectorAll('.rating-buttons button');
@@ -199,6 +225,7 @@
                 <button>Perfect</button>
             </div>
             <div id="wait-message" class="waiting-message hidden"><span class="spinner"></span>Waiting for others...</div>
+            <div id="session-users" class="session-users hidden"></div>
         </div>
         <div id="finished-container" class="finished" style="display:none;">
             <h2>All skins have been rated!</h2>

--- a/styles.css
+++ b/styles.css
@@ -234,6 +234,20 @@ button:hover {
     font-weight: bold;
 }
 
+.session-users {
+    margin-top: 0.3rem;
+    font-size: 0.9rem;
+}
+.session-users span {
+    margin-right: 0.4rem;
+}
+.session-users .waiting {
+    color: #f85149;
+}
+.session-users .rated {
+    color: #6fdd8b;
+}
+
 .spinner {
     display: inline-block;
     width: 16px;

--- a/styles.css
+++ b/styles.css
@@ -234,6 +234,22 @@ button:hover {
     font-weight: bold;
 }
 
+.spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid #c9d1d9;
+    border-top-color: transparent;
+    border-radius: 50%;
+    margin-right: 6px;
+    animation: spin 0.8s linear infinite;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
 .finished {
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- track active participants in the sync session
- update server endpoints to use participant list
- include user in sync toggle requests on client
- show returned skin immediately on toggle
- handle waiting screen more accurately and show spinner when waiting

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688c74ffe898832d97a0cd24fd6c01f4