### PR TITLE
feat: use Zen Old Mincho for category headings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,8 @@
  * colours are chosen to evoke a dark gaming aesthetic.
  */
 
+@import url('https://fonts.googleapis.com/css2?family=Zen+Old+Mincho&display=swap');
+
 /* Global styles */
 body {
     margin: 0;
@@ -12,6 +14,9 @@ body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     background-color: #0d1117;
     color: #c9d1d9;
+}
+h2 {
+    font-family: 'Zen Old Mincho', serif;
 }
 a { color: #58a6ff; text-decoration: none; }
 a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary
- import Zen Old Mincho font
- apply Zen Old Mincho to h2 elements for category headers

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e07530344832dbb2991bb29d0b91a